### PR TITLE
Sync Groups on Login Support

### DIFF
--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
@@ -47,6 +47,7 @@
         <property name="nodeService" ref="nodeService" />
         <property name="personService" ref="personService" />
         <property name="transactionService" ref="transactionService" />
+        <property name="authorityService" ref="authorityService" />
         <property name="active" value="${keycloak.authentication.enabled}" />
         <property name="defaultAdministratorUserNameList" value="${keycloak.authentication.defaultAdministratorUserNames}" />
         <property name="allowUserNamePasswordLogin" value="${keycloak.authentication.allowUserNamePasswordLogin}" />
@@ -54,6 +55,7 @@
         <property name="failExpiredTicketTokens" value="${keycloak.authentication.failExpiredTicketTokens}" />
         <property name="mapAuthorities" value="${keycloak.authentication.mapAuthorities}" />
         <property name="mapPersonPropertiesOnLogin" value="${keycloak.authentication.mapPersonPropertiesOnLogin}" />
+        <property name="syncAuthorityMembershipOnLogin" value="${keycloak.authentication.syncAuthorityMembershipOnLogin}" />
         <property name="deployment" ref="keycloakDeployment" />
     </bean>
     

--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
@@ -55,6 +55,7 @@
         <property name="failExpiredTicketTokens" value="${keycloak.authentication.failExpiredTicketTokens}" />
         <property name="mapAuthorities" value="${keycloak.authentication.mapAuthorities}" />
         <property name="mapPersonPropertiesOnLogin" value="${keycloak.authentication.mapPersonPropertiesOnLogin}" />
+        <property name="syncAuthoritiesOnLogin" value="${keycloak.authentication.syncAuthoritiesOnLogin}" />
         <property name="syncAuthorityMembershipOnLogin" value="${keycloak.authentication.syncAuthorityMembershipOnLogin}" />
         <property name="deployment" ref="keycloakDeployment" />
     </bean>

--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
@@ -10,6 +10,7 @@ keycloak.authentication.failExpiredTicketTokens=false
 keycloak.authentication.allowGuestLogin=true
 keycloak.authentication.mapAuthorities=true
 keycloak.authentication.mapPersonPropertiesOnLogin=true
+keycloak.authentication.syncAuthorityMembershipOnLogin=false
 keycloak.authentication.authenticateFTP=true
 keycloak.authentication.silentRemoteUserValidationFailure=true
 

--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
@@ -10,6 +10,7 @@ keycloak.authentication.failExpiredTicketTokens=false
 keycloak.authentication.allowGuestLogin=true
 keycloak.authentication.mapAuthorities=true
 keycloak.authentication.mapPersonPropertiesOnLogin=true
+keycloak.authentication.syncAuthoritiesOnLogin=false
 keycloak.authentication.syncAuthorityMembershipOnLogin=false
 keycloak.authentication.authenticateFTP=true
 keycloak.authentication.silentRemoteUserValidationFailure=true

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationFilter.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationFilter.java
@@ -989,7 +989,7 @@ public class KeycloakAuthenticationFilter extends BaseAuthenticationFilter
             if (sessionUser == null)
             {
                 LOGGER.debug("Propagating through the user identity: {}", AlfrescoCompatibilityUtil.maskUsername(userId));
-                this.authenticationComponent.setCurrentUser(userId);
+                this.keycloakAuthenticationComponent.setCurrentUser(userId);
                 session = httpServletRequest.getSession();
 
                 try


### PR DESCRIPTION
I have a requirement where we cannot use LDAP and there is no service call that can be made to sync users/groups or their membership.  All of it has to be determined when the user signs in.  The identity service is also based on Ping Identity.

I decided to try out this module combined with Alfresco Identity Service (keycloak server).  All worked except for that sync.  So I added sync functionality where I felt appropriate.  It certainly needs some work.  However, it is a first pass that I will improve upon over the coming months.

So I am putting this out there in case you want to incorporate it or track it as a separate branch.