### PR TITLE
setCurrentUser() Race Condition

### DIFF
--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
@@ -49,8 +49,6 @@
         <property name="allowUserNamePasswordLogin" value="${keycloak.authentication.allowUserNamePasswordLogin}" />
         <property name="allowGuestLogin" value="${keycloak.authentication.allowGuestLogin}" />
         <property name="failExpiredTicketTokens" value="${keycloak.authentication.failExpiredTicketTokens}" />
-        <property name="mapAuthorities" value="${keycloak.authentication.mapAuthorities}" />
-        <property name="mapPersonPropertiesOnLogin" value="${keycloak.authentication.mapPersonPropertiesOnLogin}" />
         <property name="deployment" ref="keycloakDeployment" />
     </bean>
     
@@ -187,6 +185,11 @@
         <property name="enabled" value="${keycloak.roles.mapRoles}" />
         <property name="processRealmRoles" value="${keycloak.roles.mapRealmRoles}" />
         <property name="processResourceRoles" value="${keycloak.roles.mapResourceRoles}" />
+    </bean>
+
+    <bean id="authorityMapper" class="${project.artifactId}.authentication.KeycloakTokenAuthorityMapper">
+        <property name="enabled" value="${keycloak.authentication.mapAuthorities}" />
+        <property name="mapPersonPropertiesOnLogin" value="${keycloak.authentication.mapPersonPropertiesOnLogin}" />
     </bean>
 
     <bean id="userAuthority.default" class="${project.artifactId}.authentication.DefaultAuthorityExtractor">

--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication-context.xml
@@ -201,6 +201,12 @@
 
     <bean id="userToken.default" class="${project.artifactId}.authentication.DefaultPersonProcessor" />
 
+    <bean id="authoritySync" class="${project.artifactId}.authentication.KeycloakTokenAuthoritySync">
+        <property name="enabled" value="${keycloak.authentication.syncAuthoritiesOnLogin}" />
+        <property name="syncAuthorityMembershipOnLogin" value="${keycloak.authentication.syncAuthorityMembershipOnLogin}" />
+        <property name="authorityService" ref="authorityService" />
+    </bean>
+
     <bean id="userFilter.containedInGroup" class="${project.artifactId}.sync.GroupContainmentUserFilter">
         <property name="identitiesClient" ref="identitiesClient" />
     </bean>

--- a/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
+++ b/repository/src/main/globalConfig/subsystems/Authentication/keycloak/keycloak-authentication.properties
@@ -13,6 +13,10 @@ keycloak.authentication.mapPersonPropertiesOnLogin=true
 keycloak.authentication.authenticateFTP=true
 keycloak.authentication.silentRemoteUserValidationFailure=true
 
+# Authority Sync plugin
+keycloak.authentication.syncAuthoritiesOnLogin=false
+keycloak.authentication.syncAuthorityMembershipOnLogin=false
+
 keycloak.authentication.bodyBufferLimit=10485760
 
 keycloak.adapter.auth-server-url=http://localhost:8180/auth

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationComponent.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationComponent.java
@@ -15,26 +15,13 @@
  */
 package de.acosix.alfresco.keycloak.repo.authentication;
 
-import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.alfresco.repo.management.subsystems.ActivateableBean;
 import org.alfresco.repo.security.authentication.AbstractAuthenticationComponent;
 import org.alfresco.repo.security.authentication.AuthenticationException;
-import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
-import org.alfresco.repo.transaction.AlfrescoTransactionSupport.TxnReadState;
-import org.alfresco.service.cmr.repository.NodeRef;
-import org.alfresco.service.cmr.repository.NodeService;
-import org.alfresco.service.namespace.QName;
 import org.alfresco.util.PropertyCheck;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.representations.AccessToken;
@@ -48,12 +35,7 @@ import org.springframework.context.ApplicationContextAware;
 import de.acosix.alfresco.keycloak.repo.token.AccessTokenClient;
 import de.acosix.alfresco.keycloak.repo.token.AccessTokenException;
 import de.acosix.alfresco.keycloak.repo.token.AccessTokenRefreshException;
-import de.acosix.alfresco.keycloak.repo.util.AlfrescoCompatibilityUtil;
 import de.acosix.alfresco.keycloak.repo.util.RefreshableAccessTokenHolder;
-import net.sf.acegisecurity.Authentication;
-import net.sf.acegisecurity.GrantedAuthority;
-import net.sf.acegisecurity.GrantedAuthorityImpl;
-import net.sf.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 
 /**
  * This component provides Keycloak-integrated user/password authentication support to an Alfresco instance.
@@ -80,17 +62,11 @@ public class KeycloakAuthenticationComponent extends AbstractAuthenticationCompo
 
     protected boolean allowGuestLogin;
 
-    protected boolean mapAuthorities;
-
-    protected boolean mapPersonPropertiesOnLogin;
-
     protected KeycloakDeployment deployment;
 
     protected AccessTokenClient accessTokenClient;
-
-    protected Collection<AuthorityExtractor> authorityExtractors;
-
-    protected Collection<UserProcessor> userProcessors;
+    
+    protected List<TokenProcessor> tokenProcessors;
 
     /**
      *
@@ -103,10 +79,10 @@ public class KeycloakAuthenticationComponent extends AbstractAuthenticationCompo
         PropertyCheck.mandatory(this, "keycloakDeployment", this.deployment);
 
         this.accessTokenClient = new AccessTokenClient(this.deployment);
-        this.authorityExtractors = Collections
-                .unmodifiableList(new ArrayList<>(this.applicationContext.getBeansOfType(AuthorityExtractor.class, false, true).values()));
-        this.userProcessors = Collections
-                .unmodifiableList(new ArrayList<>(this.applicationContext.getBeansOfType(UserProcessor.class, false, true).values()));
+        
+        List<TokenProcessor> tokenProcessors = new ArrayList<>(this.applicationContext.getBeansOfType(TokenProcessor.class, false, true).values());
+        Collections.sort(tokenProcessors);
+        this.tokenProcessors = Collections.unmodifiableList(tokenProcessors);
     }
 
     /**
@@ -172,24 +148,6 @@ public class KeycloakAuthenticationComponent extends AbstractAuthenticationCompo
     public void setAllowGuestLogin(final Boolean allowGuestLogin)
     {
         this.setAllowGuestLogin(Boolean.TRUE.equals(allowGuestLogin));
-    }
-
-    /**
-     * @param mapAuthorities
-     *     the mapAuthorities to set
-     */
-    public void setMapAuthorities(final boolean mapAuthorities)
-    {
-        this.mapAuthorities = mapAuthorities;
-    }
-
-    /**
-     * @param mapPersonPropertiesOnLogin
-     *     the mapPersonPropertiesOnLogin to set
-     */
-    public void setMapPersonPropertiesOnLogin(final boolean mapPersonPropertiesOnLogin)
-    {
-        this.mapPersonPropertiesOnLogin = mapPersonPropertiesOnLogin;
     }
 
     /**
@@ -323,89 +281,11 @@ public class KeycloakAuthenticationComponent extends AbstractAuthenticationCompo
      */
     public void handleUserTokens(final AccessToken accessToken, final IDToken idToken, final boolean freshLogin)
     {
-        if (this.mapAuthorities)
-        {
-            LOGGER.debug("Mapping Keycloak access token to user authorities");
-
-            final Set<String> mappedAuthorities = new HashSet<>();
-            this.authorityExtractors.stream().map(extractor -> extractor.extractAuthorities(accessToken))
-                    .forEach(mappedAuthorities::addAll);
-
-            LOGGER.debug("Mapped user authorities from access token: {}", mappedAuthorities);
-
-            if (!mappedAuthorities.isEmpty())
-            {
-                final Authentication currentAuthentication = this.getCurrentAuthentication();
-                if (currentAuthentication instanceof UsernamePasswordAuthenticationToken)
-                {
-                    GrantedAuthority[] grantedAuthorities = currentAuthentication.getAuthorities();
-
-                    final List<GrantedAuthority> grantedAuthoritiesL = mappedAuthorities.stream().map(GrantedAuthorityImpl::new)
-                            .collect(Collectors.toList());
-                    grantedAuthoritiesL.addAll(Arrays.asList(grantedAuthorities));
-
-                    grantedAuthorities = grantedAuthoritiesL.toArray(new GrantedAuthority[0]);
-                    ((UsernamePasswordAuthenticationToken) currentAuthentication).setAuthorities(grantedAuthorities);
-                }
-                else
-                {
-                    LOGGER.warn(
-                            "Authentication for user is not of the expected type {} - Keycloak access token cannot be mapped to granted authorities",
-                            UsernamePasswordAuthenticationToken.class);
-                }
-            }
-        }
-
-        if (freshLogin && this.mapPersonPropertiesOnLogin)
-        {
-            final boolean requiresNew = AlfrescoTransactionSupport.getTransactionReadState() == TxnReadState.TXN_READ_ONLY;
-            this.getTransactionService().getRetryingTransactionHelper().doInTransaction(() -> {
-                this.updatePerson(accessToken, idToken);
-                return null;
-            }, false, requiresNew);
-        }
-    }
-
-    /**
-     * Updates the person for the current user with data mapped from the Keycloak tokens.
-     *
-     * @param accessToken
-     *     the access token
-     * @param idToken
-     *     the ID token
-     */
-    protected void updatePerson(final AccessToken accessToken, final IDToken idToken)
-    {
-        final String userName = this.getCurrentUserName();
-
-        LOGGER.debug("Mapping person property updates for user {}", AlfrescoCompatibilityUtil.maskUsername(userName));
-
-        final NodeRef person = this.getPersonService().getPerson(userName);
-
-        final Map<QName, Serializable> updates = new HashMap<>();
-        this.userProcessors.forEach(processor -> processor.mapUser(accessToken, idToken != null ? idToken : accessToken, updates));
-
-        LOGGER.debug("Determined property updates for person node of user {}", AlfrescoCompatibilityUtil.maskUsername(userName));
-
-        final Set<QName> propertiesToRemove = updates.keySet().stream().filter(k -> updates.get(k) == null).collect(Collectors.toSet());
-        updates.keySet().removeAll(propertiesToRemove);
-
-        final NodeService nodeService = this.getNodeService();
-        final Map<QName, Serializable> currentProperties = nodeService.getProperties(person);
-
-        propertiesToRemove.retainAll(currentProperties.keySet());
-        if (!propertiesToRemove.isEmpty())
-        {
-            // there is no bulk-remove, so we need to use setProperties to achieve a single update event
-            final Map<QName, Serializable> newProperties = new HashMap<>(currentProperties);
-            newProperties.putAll(updates);
-            newProperties.keySet().removeAll(propertiesToRemove);
-            nodeService.setProperties(person, newProperties);
-        }
-        else if (!updates.isEmpty())
-        {
-            nodeService.addProperties(person, updates);
-        }
+    	for (TokenProcessor processor : this.tokenProcessors)
+    	{
+            LOGGER.debug("Processing token with {}", processor.getName());
+    		processor.handleUserTokens(this, accessToken, idToken, freshLogin);
+    	}
     }
 
     /**

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationFilter.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakAuthenticationFilter.java
@@ -986,7 +986,7 @@ public class KeycloakAuthenticationFilter extends BaseAuthenticationFilter
             if (sessionUser == null)
             {
                 LOGGER.debug("Propagating through the user identity: {}", AlfrescoCompatibilityUtil.maskUsername(userId));
-                this.authenticationComponent.setCurrentUser(userId);
+                this.keycloakAuthenticationComponent.setCurrentUser(userId);
                 session = httpServletRequest.getSession();
 
                 try

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakTokenAuthorityMapper.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakTokenAuthorityMapper.java
@@ -1,0 +1,171 @@
+package de.acosix.alfresco.keycloak.repo.authentication;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.alfresco.repo.security.authentication.AbstractAuthenticationComponent;
+import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
+import org.alfresco.repo.transaction.AlfrescoTransactionSupport.TxnReadState;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.namespace.QName;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import de.acosix.alfresco.keycloak.repo.util.AlfrescoCompatibilityUtil;
+import net.sf.acegisecurity.Authentication;
+import net.sf.acegisecurity.GrantedAuthority;
+import net.sf.acegisecurity.GrantedAuthorityImpl;
+import net.sf.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+
+public class KeycloakTokenAuthorityMapper implements TokenProcessor, InitializingBean, ApplicationContextAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeycloakTokenAuthorityMapper.class);
+    
+    private static final String NAME = "AuthorityMapper";
+
+    protected ApplicationContext applicationContext;
+
+    protected boolean enabled;
+    
+    protected boolean mapPersonPropertiesOnLogin;
+
+    protected Collection<AuthorityExtractor> authorityExtractors;
+
+    protected Collection<UserProcessor> userProcessors;
+    
+    @Override
+    public String getName() {
+    	return NAME;
+    }
+    
+    public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+    /**
+     * @param mapPersonPropertiesOnLogin
+     *     the mapPersonPropertiesOnLogin to set
+     */
+    public void setMapPersonPropertiesOnLogin(final boolean mapPersonPropertiesOnLogin) {
+        this.mapPersonPropertiesOnLogin = mapPersonPropertiesOnLogin;
+    }
+    
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+    	this.applicationContext = applicationContext;
+    }
+    
+    @Override
+    public void afterPropertiesSet() throws BeansException {
+        this.authorityExtractors = Collections
+                .unmodifiableList(new ArrayList<>(this.applicationContext.getBeansOfType(AuthorityExtractor.class, false, true).values()));
+        this.userProcessors = Collections
+                .unmodifiableList(new ArrayList<>(this.applicationContext.getBeansOfType(UserProcessor.class, false, true).values()));
+    }
+	
+	@Override
+	public void handleUserTokens(AbstractAuthenticationComponent authComponent, AccessToken accessToken,
+			IDToken idToken, boolean freshLogin) {
+		if (!this.enabled)
+			return;
+		
+        LOGGER.debug("Mapping Keycloak access token to user authorities");
+
+        final Set<String> mappedAuthorities = new HashSet<>();
+        this.authorityExtractors.stream().map(extractor -> extractor.extractAuthorities(accessToken))
+                .forEach(mappedAuthorities::addAll);
+
+        LOGGER.debug("Mapped user authorities from access token: {}", mappedAuthorities);
+
+        if (!mappedAuthorities.isEmpty())
+        {
+            final Authentication currentAuthentication = authComponent.getCurrentAuthentication();
+            if (currentAuthentication instanceof UsernamePasswordAuthenticationToken)
+            {
+                GrantedAuthority[] grantedAuthorities = currentAuthentication.getAuthorities();
+
+                final List<GrantedAuthority> grantedAuthoritiesL = mappedAuthorities.stream().map(GrantedAuthorityImpl::new)
+                        .collect(Collectors.toList());
+                grantedAuthoritiesL.addAll(Arrays.asList(grantedAuthorities));
+
+                grantedAuthorities = grantedAuthoritiesL.toArray(new GrantedAuthority[0]);
+                ((UsernamePasswordAuthenticationToken) currentAuthentication).setAuthorities(grantedAuthorities);
+            }
+            else
+            {
+                LOGGER.warn(
+                        "Authentication for user is not of the expected type {} - Keycloak access token cannot be mapped to granted authorities",
+                        UsernamePasswordAuthenticationToken.class);
+            }
+        }
+        
+        if (freshLogin && this.mapPersonPropertiesOnLogin)
+        {
+            final boolean requiresNew = AlfrescoTransactionSupport.getTransactionReadState() == TxnReadState.TXN_READ_ONLY;
+            authComponent.getTransactionService().getRetryingTransactionHelper().doInTransaction(() -> {
+                this.updatePerson(authComponent, accessToken, idToken);
+                return null;
+            }, false, requiresNew);
+        }
+	}
+
+    /**
+     * Updates the person for the current user with data mapped from the Keycloak tokens.
+     *
+     * @param accessToken
+     *     the access token
+     * @param idToken
+     *     the ID token
+     */
+    protected void updatePerson(AbstractAuthenticationComponent authComponent,
+    		final AccessToken accessToken, final IDToken idToken)
+    {
+        final String userName = authComponent.getCurrentUserName();
+
+        LOGGER.debug("Mapping person property updates for user {}", AlfrescoCompatibilityUtil.maskUsername(userName));
+
+        final NodeRef person = authComponent.getPersonService().getPerson(userName);
+
+        final Map<QName, Serializable> updates = new HashMap<>();
+        this.userProcessors.forEach(processor -> processor.mapUser(accessToken, idToken != null ? idToken : accessToken, updates));
+
+        LOGGER.debug("Determined property updates for person node of user {}", AlfrescoCompatibilityUtil.maskUsername(userName));
+
+        final Set<QName> propertiesToRemove = updates.keySet().stream().filter(k -> updates.get(k) == null).collect(Collectors.toSet());
+        updates.keySet().removeAll(propertiesToRemove);
+
+        final NodeService nodeService = authComponent.getNodeService();
+        final Map<QName, Serializable> currentProperties = nodeService.getProperties(person);
+
+        propertiesToRemove.retainAll(currentProperties.keySet());
+        if (!propertiesToRemove.isEmpty())
+        {
+            // there is no bulk-remove, so we need to use setProperties to achieve a single update event
+            final Map<QName, Serializable> newProperties = new HashMap<>(currentProperties);
+            newProperties.putAll(updates);
+            newProperties.keySet().removeAll(propertiesToRemove);
+            nodeService.setProperties(person, newProperties);
+        }
+        else if (!updates.isEmpty())
+        {
+            nodeService.addProperties(person, updates);
+        }
+    }
+
+}

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakTokenAuthoritySync.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/KeycloakTokenAuthoritySync.java
@@ -1,0 +1,249 @@
+package de.acosix.alfresco.keycloak.repo.authentication;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.alfresco.repo.security.authentication.AbstractAuthenticationComponent;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
+import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
+import org.alfresco.repo.transaction.AlfrescoTransactionSupport.TxnReadState;
+import org.alfresco.service.cmr.repository.DuplicateChildNodeNameException;
+import org.alfresco.service.cmr.security.AuthorityService;
+import org.alfresco.service.cmr.security.AuthorityType;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.acosix.alfresco.keycloak.repo.util.AlfrescoCompatibilityUtil;
+import net.sf.acegisecurity.GrantedAuthority;
+
+public class KeycloakTokenAuthoritySync implements TokenProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeycloakTokenAuthoritySync.class);
+
+    private static final String NAME = "AuthoritySync";
+    
+    protected boolean enabled;
+    
+    protected boolean syncAuthorityMembershipOnLogin;
+    
+    protected AuthorityService authorityService;
+    
+    public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+    /**
+     * @param syncAuthorityMembershipOnLogin
+     *            the syncAuthorityMembershipOnLogin to set
+     */
+    public void setSyncAuthorityMembershipOnLogin(final boolean syncAuthorityMembershipOnLogin) {
+        this.syncAuthorityMembershipOnLogin = syncAuthorityMembershipOnLogin;
+    }
+    
+    public void setAuthorityService(AuthorityService authorityService) {
+		this.authorityService = authorityService;
+	}
+    
+    @Override
+    public String getName() {
+    	return NAME;
+    }
+    
+    @Override
+    public int getPriority() {
+    	return 16;
+    }
+	
+	@Override
+	public void handleUserTokens(AbstractAuthenticationComponent authComponent, AccessToken accessToken,
+			IDToken idToken, boolean freshLogin) {
+		if (!this.enabled)
+			return;
+		
+		if (freshLogin) {
+	        boolean requiresNew = AlfrescoTransactionSupport.getTransactionReadState() == TxnReadState.TXN_READ_ONLY;
+	        authComponent.getTransactionService().getRetryingTransactionHelper().doInTransaction(() -> {
+	    		GrantedAuthority[] authorities = authComponent.getCurrentAuthentication().getAuthorities();
+	    		this.syncAuthorities(Arrays.asList(authorities), accessToken, idToken);
+	            return null;
+	        }, false, requiresNew);
+	
+	    	if (this.syncAuthorityMembershipOnLogin)
+	    	{
+	            authComponent.getTransactionService().getRetryingTransactionHelper().doInTransaction(() -> {
+	                String userName = authComponent.getCurrentUserName();
+	        		GrantedAuthority[] authorities = authComponent.getCurrentAuthentication().getAuthorities();
+	        		this.syncAuthorityMemberships(userName, Arrays.asList(authorities), accessToken, idToken);
+	                return null;
+	            }, false, requiresNew);
+	    	}
+		}
+	}
+    
+    /**
+     * Synchronizes the groups of the current user, but not the membership, as Alfresco user groups.
+     * @param authorities
+     *            the Alfresco authorities to persist as user groups
+     * @param accessToken
+     *            the access token
+     * @param idToken
+     *            the ID token
+     */
+    protected void syncAuthorities(final Collection<GrantedAuthority> authorities, final AccessToken accessToken, final IDToken idToken)
+    {
+        LOGGER.debug("Synchronizing user groups {}", authorities);
+
+		AuthenticationUtil.runAsSystem(new RunAsLoggableWork<Void>() {
+			@Override
+			public Void doLoggedWork() {
+		        for (GrantedAuthority authority : authorities)
+		        {
+		        	String authorityId = authority.getAuthority();
+		
+		        	if (AuthorityType.GROUP.equals(AuthorityType.getAuthorityType(authorityId)))
+		        	{
+		        		// we only persist groups (not roles) in Alfresco
+		            	
+	            		// if it didn't exist, then we need to associate the user to the group
+	            		if (!authorityService.authorityExists(authorityId))
+	            		{
+	                		// group does not yet exist; create one
+	            			
+	                		if (LOGGER.isDebugEnabled())
+	                			LOGGER.debug("Creating authority {}", authorityId);
+
+	                		String authorityShortName = authorityService.getShortName(authorityId);
+	                		authorityShortName = normalizeAuthority(authorityShortName);
+
+	                		if (LOGGER.isDebugEnabled())
+	                			LOGGER.debug("Creating group {}", authorityShortName);
+	                		
+	                		try {
+	                			authorityService.createAuthority(AuthorityType.GROUP, authorityShortName);
+	                		} catch (DuplicateChildNodeNameException dcnne) {
+	                			LOGGER.debug("Group {} already created; race condition?", authorityShortName);
+	                		}
+	            		}
+		        	}
+		        }
+		        
+		        return null;
+			}
+		});
+    }
+    
+    /**
+     * Synchronizes the membership of the current user with the authority, as an Alfresco user group.
+     * @param authorities
+     *            the Alfresco authorities to persist as user groups
+     * @param accessToken
+     *            the access token
+     * @param idToken
+     *            the ID token
+     */
+    protected void syncAuthorityMemberships(String userName, final Collection<GrantedAuthority> authorities, final AccessToken accessToken, final IDToken idToken)
+    {
+		if (LOGGER.isDebugEnabled())
+			LOGGER.debug("Synchronizing user group membership for user {}", AlfrescoCompatibilityUtil.maskUsername(userName));
+
+		String userAuthorityId = this.authorityService.getName(AuthorityType.USER, userName);
+        Set<String> persistedAuthorityIds = new HashSet<>(this.authorityService.getAuthoritiesForUser(userName));
+
+		if (LOGGER.isDebugEnabled())
+			LOGGER.debug("Current authorities for user {}: {}", AlfrescoCompatibilityUtil.maskUsername(userName), persistedAuthorityIds);
+
+		AuthenticationUtil.runAsSystem(new RunAsLoggableWork<Void>() {
+			@Override
+			public Void doLoggedWork() throws Exception {
+		        for (GrantedAuthority authority : authorities)
+		        {
+		        	String authorityId = authority.getAuthority();
+            		LOGGER.trace("Inspecting authority '{}' to grant membership", authorityId);
+		
+		        	if (AuthorityType.GROUP.equals(AuthorityType.getAuthorityType(authorityId)))
+		        	{
+		        		// we only persist groups in Alfresco
+		
+		            	// remove if it exists; any remaining GROUP authorities will be unlinked from user later in this method
+		            	persistedAuthorityIds.remove(authorityId);
+		            	// we cannot assume persistedAuthorityIds has only registered groups; it includes authorities from keycloak
+		            	
+		            	authorityId = normalizeAuthority(authorityId);
+	            		
+	            		if (LOGGER.isDebugEnabled())
+	            			LOGGER.debug("Adding user {} to group {}", AlfrescoCompatibilityUtil.maskUsername(userName), authorityId);
+	            		
+	            		try {
+		            		// add the user to the existing group
+		                    authorityService.addAuthority(authorityId, userAuthorityId);
+	            		} catch (DuplicateChildNodeNameException dcnne) {
+	            			if (LOGGER.isTraceEnabled())
+	            				LOGGER.trace("User {} is already a member of group {}", AlfrescoCompatibilityUtil.maskUsername(userName), authorityId);
+	            		}
+		        	}
+		        }
+
+		        if (LOGGER.isDebugEnabled())
+		        	LOGGER.debug("Removing user {} from authorities: {}", AlfrescoCompatibilityUtil.maskUsername(userName), persistedAuthorityIds);
+		        
+		        // revoke user from groups
+		        for (String persistedAuthorityId : persistedAuthorityIds)
+		        {
+            		LOGGER.trace("Inspecting authority '{}' to revoke membership", persistedAuthorityId);
+            		
+		        	if (AuthorityType.GROUP.equals(AuthorityType.getAuthorityType(persistedAuthorityId)))
+		        	{
+		        		// disassociate persisted groups only
+		        		persistedAuthorityId = normalizeAuthority(persistedAuthorityId);
+		        		
+		        		if (LOGGER.isDebugEnabled())
+		        			LOGGER.debug("Removing user {} from group {}", AlfrescoCompatibilityUtil.maskUsername(userName), persistedAuthorityId);
+		        		
+		            	authorityService.removeAuthority(persistedAuthorityId, userAuthorityId);
+		        	}
+		        }
+		        
+		        return null;
+			}
+		});
+    }
+    
+    private String normalizeAuthority(String authorityIdOrShortName) {
+    	// in case we need to filter out special characters
+    	return authorityIdOrShortName;
+    }
+    
+    
+    
+    private interface RunAsLoggableWork<T> extends RunAsWork<T> {
+    	
+    	default T doWork() throws Exception {
+    		long time = System.currentTimeMillis();
+			LOGGER.trace("doWork()");
+			
+			T result;
+    		try {
+    			result = this.doLoggedWork();
+    		} catch (Exception e) {
+    			LOGGER.error("An unhandled exception occurred", e);
+    			throw e;
+    		} catch (Throwable t) {
+    			LOGGER.error("An unhandled error occurred", t);
+    			throw t;
+    		}
+
+			LOGGER.trace("doWork(): completed in {} ms", System.currentTimeMillis() - time);
+			
+			return result;
+    	}
+    	
+    	T doLoggedWork() throws Exception;
+    	
+    }
+
+}

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/TokenProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/TokenProcessor.java
@@ -1,0 +1,51 @@
+package de.acosix.alfresco.keycloak.repo.authentication;
+
+import org.alfresco.repo.security.authentication.AbstractAuthenticationComponent;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+
+/**
+ * Instances of this interface are used to process access tokens from Keycloak authenticated users. All instances of this
+ * interface in the Keycloak authentication subsystem will be consulted in the order of the priority field, followed by the
+ * order the beans are defined in the Spring application context.
+ *
+ * @author Brian Long
+ */
+public interface TokenProcessor extends Comparable<TokenProcessor> {
+	
+	/**
+	 * A name of the processor for logging and reference purposes.
+	 * @return A processor name.
+	 */
+	String getName();
+	
+	/**
+	 * A priority for sorting beans for execution order.
+	 * @return
+	 */
+	default int getPriority() {
+		return 0;
+	}
+
+    /**
+     * Handles access tokens from Keycloak.
+     *
+     * @param accessToken
+     *            the Keycloak access token for the authenticated user
+     * @param idToken
+     *            the Keycloak ID token for the authenticated user - may be {@code null} if not contained in the authentication response
+     * @param freshLogin
+     *            {@code true} if the tokens are fresh, that is have just been obtained from an initial login, {@code false} otherwise
+     */
+	void handleUserTokens(
+			final AbstractAuthenticationComponent authComponent,
+			final AccessToken accessToken,
+			final IDToken idToken,
+			final boolean freshLogin);
+	
+	@Override
+	default int compareTo(TokenProcessor o) {
+		return Integer.compare(this.getPriority(), o.getPriority());
+	}
+
+}


### PR DESCRIPTION
This places a retrying block around setCurrentUser() to resolve a race condition I am seeing without such a block in place.  This is most helpful when users are on angular-based interfaces, like ADW/ADF.

Maybe there is a better solution, but this has worked for us.