### PR TITLE
Handle alfRedirectUrl parameter on login page

### DIFF
--- a/docker-test/src/main/resources/share/share-config-custom.xml
+++ b/docker-test/src/main/resources/share/share-config-custom.xml
@@ -34,6 +34,15 @@
             </authenticator>
 
             <endpoint>
+                <id>alfresco-noauth</id>
+                <name>Alfresco - unauthenticated access</name>
+                <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+                <connector-id>alfresco</connector-id>
+                <endpoint-url>http://repository:8080/alfresco/s</endpoint-url>
+                <identity>none</identity>
+            </endpoint>
+
+            <endpoint>
                 <id>alfresco</id>
                 <name>Alfresco - user access</name>
                 <description>Access to Alfresco Repository WebScripts that require user authentication</description>
@@ -71,7 +80,7 @@
         <keycloak-auth-config>
             <enhance-login-form>true</enhance-login-form>
             <enable-sso-filter>true</enable-sso-filter>
-            <force-keycloak-sso>false</force-keycloak-sso>
+            <force-keycloak-sso>true</force-keycloak-sso>
             <perform-token-exchange>true</perform-token-exchange>
         </keycloak-auth-config>
         <keycloak-adapter-config>
@@ -88,4 +97,61 @@
         </keycloak-adapter-config>
     </config>
 
+    <!-- Must be specified (typically provided as part of packaging) -->
+   <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+      <tree>
+         <evaluate-child-folders>false</evaluate-child-folders>
+         <maximum-folder-count>1000</maximum-folder-count>
+         <timeout>7000</timeout>
+      </tree>
+      <aspects>
+         <!-- Aspects that a user can see -->
+         <visible>
+            <aspect name="cm:generalclassifiable" />
+            <aspect name="cm:complianceable" />
+            <aspect name="cm:dublincore" />
+            <aspect name="cm:effectivity" />
+            <aspect name="cm:summarizable" />
+            <aspect name="cm:versionable" />
+            <aspect name="cm:templatable" />
+            <aspect name="cm:emailed" />
+            <aspect name="emailserver:aliasable" />
+            <aspect name="cm:taggable" />
+            <aspect name="app:inlineeditable" />
+            <aspect name="cm:geographic" />
+            <aspect name="exif:exif" />
+            <aspect name="audio:audio" />
+            <aspect name="cm:indexControl" />
+            <aspect name="dp:restrictable" />
+            <aspect name="smf:customConfigSmartFolder" />
+            <aspect name="smf:systemConfigSmartFolder" />
+         </visible>
+         <addable>
+         </addable>
+         <removeable>
+         </removeable>
+      </aspects>
+      <types>
+         <type name="cm:content">
+            <subtype name="smf:smartFolderTemplate" />
+         </type>
+          <type name="cm:folder">
+         </type>
+         <type name="trx:transferTarget">
+            <subtype name="trx:fileTransferTarget" />
+         </type>
+      </types>
+      <repository-url>http://repository:8080/alfresco</repository-url>
+      <google-docs>
+         <enabled>false</enabled>
+         <creatable-types>
+            <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+            <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+            <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+         </creatable-types>
+      </google-docs>
+      <file-upload>
+         <adobe-flash-enabled>false</adobe-flash-enabled>
+      </file-upload>
+   </config>
 </alfresco-config>

--- a/share/src/main/site-webscripts/de/acosix/keycloak/customisations/components/guest/login.get.js
+++ b/share/src/main/site-webscripts/de/acosix/keycloak/customisations/components/guest/login.get.js
@@ -44,7 +44,17 @@ function main()
                     parameterModel.value = decodeURIComponent(parameter.substring(parameter.indexOf('=') + 1));
                     if (parameterModel.value.indexOf('?') !== -1)
                     {
-                        parameterModel.value = parameterModel.value.substring(0, parameterModel.value.indexOf('?'));
+                        if (parameterModel.value.indexOf('?alfRedirectUrl=') !== -1)
+                        {
+                            if (parameterModel.value.indexOf('&') !== -1)
+                            {
+                                parameterModel.value = parameterModel.value.substring(0, parameterModel.value.indexOf('&'));
+                            }
+                        }
+                        else
+                        {
+                            parameterModel.value = parameterModel.value.substring(0, parameterModel.value.indexOf('?'));
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
This pull request addresses some aspects of #29 when this module is used in combination with a feature that uses the `alfRedirectUrl` parameter on the explicit login page URL. The login page URL would use that URL to redirect the user after a successful authentication. Until this pull request, we had stripped any URL parameters added to the redirect URL as all those encountered so far came from the Keycloak libraries. In this case, we must keep the URL parameter when preparing the login form customisation.