### PR TITLE
Improve user/group name synchronisation handling + fix resource role exposure

### DIFF
--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/roles/RoleServiceImpl.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/roles/RoleServiceImpl.java
@@ -466,7 +466,7 @@ public class RoleServiceImpl implements RoleService, InitializingBean
     {
         List<Role> roles;
 
-        if (this.enabled && !this.processResourceRoles)
+        if (this.enabled && this.processResourceRoles)
         {
             final RoleNameFilter roleNameFilter = this.resourceRoleNameFilter.get(resourceName);
             final RoleNameMapper roleNameMapper = this.resourceRoleNameMapper.get(resourceName);

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/BaseAttributeProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/BaseAttributeProcessor.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.alfresco.repo.security.sync.NodeDescription;
@@ -37,6 +38,8 @@ public abstract class BaseAttributeProcessor implements InitializingBean
 {
 
     protected NamespaceService namespaceService;
+
+    protected int priority = 50;
 
     protected boolean mapBlankString;
 
@@ -69,6 +72,15 @@ public abstract class BaseAttributeProcessor implements InitializingBean
     public void setNamespaceService(final NamespaceService namespaceService)
     {
         this.namespaceService = namespaceService;
+    }
+
+    /**
+     * @param priority
+     *     the priority to set
+     */
+    public void setPriority(final int priority)
+    {
+        this.priority = priority;
     }
 
     /**
@@ -168,5 +180,35 @@ public abstract class BaseAttributeProcessor implements InitializingBean
         {
             nodeDescription.getProperties().put(propertyQName, null);
         }
+    }
+
+    protected Optional<String> mapAuthorityName(final QName authorityNameProperty, final Map<String, List<String>> attributes)
+    {
+        final Optional<String> result;
+        final String attribute = this.attributePropertyQNameMappings.entrySet().stream()
+                .filter((final Map.Entry<String, QName> e) -> authorityNameProperty.equals(e.getValue())).findFirst().map(Map.Entry::getKey)
+                .orElse(null);
+        if (attribute != null)
+        {
+            List<String> attrValues = attributes.get(attribute);
+            if (attrValues != null && !this.mapBlankString)
+            {
+                attrValues = attrValues.stream().filter(Predicate.not(String::isBlank)).toList();
+            }
+
+            if (attrValues != null && attrValues.size() == 1)
+            {
+                result = Optional.of(attrValues.get(0));
+            }
+            else
+            {
+                result = Optional.empty();
+            }
+        }
+        else
+        {
+            result = Optional.empty();
+        }
+        return result;
     }
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/DefaultGroupProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/DefaultGroupProcessor.java
@@ -15,9 +15,10 @@
  */
 package de.acosix.alfresco.keycloak.repo.sync;
 
+import java.util.Optional;
+
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.sync.NodeDescription;
-import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.util.PropertyMap;
 import org.keycloak.representations.idm.GroupRepresentation;
 
@@ -45,25 +46,33 @@ public class DefaultGroupProcessor implements GroupProcessor
      * {@inheritDoc}
      */
     @Override
+    public int getPriority()
+    {
+        return Integer.MAX_VALUE;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
     public void mapGroup(final GroupRepresentation group, final NodeDescription groupNode)
     {
         if (this.enabled)
         {
             final PropertyMap properties = groupNode.getProperties();
-
-            final String existingName = DefaultTypeConverter.INSTANCE.convert(String.class,
-                    properties.get(ContentModel.PROP_AUTHORITY_NAME));
-            final String existingDisplayName = DefaultTypeConverter.INSTANCE.convert(String.class,
-                    properties.get(ContentModel.PROP_AUTHORITY_DISPLAY_NAME));
-
-            if (existingName == null || existingName.isBlank())
-            {
-                properties.put(ContentModel.PROP_AUTHORITY_NAME, group.getId());
-            }
-            if (existingDisplayName == null || existingDisplayName.isBlank())
-            {
-                properties.put(ContentModel.PROP_AUTHORITY_DISPLAY_NAME, group.getName());
-            }
+            properties.put(ContentModel.PROP_AUTHORITY_NAME, group.getId());
+            properties.put(ContentModel.PROP_AUTHORITY_DISPLAY_NAME, group.getName());
         }
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> mapGroupName(final GroupRepresentation group)
+    {
+        return this.enabled ? Optional.of(group.getId()) : Optional.empty();
     }
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/DefaultPersonProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/DefaultPersonProcessor.java
@@ -18,6 +18,7 @@ package de.acosix.alfresco.keycloak.repo.sync;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.sync.NodeDescription;
@@ -47,7 +48,7 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param enabled
-     *            the enabled to set
+     *     the enabled to set
      */
     public void setEnabled(final boolean enabled)
     {
@@ -56,7 +57,7 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param mapNull
-     *            the mapNull to set
+     *     the mapNull to set
      */
     public void setMapNull(final boolean mapNull)
     {
@@ -65,7 +66,7 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param mapFirstName
-     *            the mapFirstName to set
+     *     the mapFirstName to set
      */
     public void setMapFirstName(final boolean mapFirstName)
     {
@@ -74,7 +75,7 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param mapLastName
-     *            the mapLastName to set
+     *     the mapLastName to set
      */
     public void setMapLastName(final boolean mapLastName)
     {
@@ -83,7 +84,7 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param mapEmail
-     *            the mapEmail to set
+     *     the mapEmail to set
      */
     public void setMapEmail(final boolean mapEmail)
     {
@@ -92,11 +93,21 @@ public class DefaultPersonProcessor implements UserProcessor
 
     /**
      * @param mapEnabledState
-     *            the mapEnabledState to set
+     *     the mapEnabledState to set
      */
     public void setMapEnabledState(final boolean mapEnabledState)
     {
         this.mapEnabledState = mapEnabledState;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority()
+    {
+        return Integer.MAX_VALUE;
     }
 
     /**
@@ -110,6 +121,7 @@ public class DefaultPersonProcessor implements UserProcessor
         {
             final PropertyMap properties = person.getProperties();
 
+            properties.put(ContentModel.PROP_USERNAME, user.getUsername());
             if ((this.mapNull || user.getFirstName() != null) && this.mapFirstName)
             {
                 properties.put(ContentModel.PROP_FIRSTNAME, user.getFirstName());
@@ -140,6 +152,7 @@ public class DefaultPersonProcessor implements UserProcessor
         if (this.enabled)
         {
             mappedProperties = new ArrayList<>(4);
+            mappedProperties.add(ContentModel.PROP_USERNAME);
             if (this.mapFirstName)
             {
                 mappedProperties.add(ContentModel.PROP_FIRSTNAME);
@@ -163,5 +176,15 @@ public class DefaultPersonProcessor implements UserProcessor
         }
 
         return mappedProperties;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> mapUserName(final UserRepresentation user)
+    {
+        return this.enabled ? Optional.of(user.getUsername()) : Optional.empty();
     }
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/GroupProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/GroupProcessor.java
@@ -15,6 +15,8 @@
  */
 package de.acosix.alfresco.keycloak.repo.sync;
 
+import java.util.Optional;
+
 import org.alfresco.repo.security.sync.NodeDescription;
 import org.keycloak.representations.idm.GroupRepresentation;
 
@@ -25,16 +27,53 @@ import org.keycloak.representations.idm.GroupRepresentation;
  *
  * @author Axel Faust
  */
-public interface GroupProcessor
+public interface GroupProcessor extends Comparable<GroupProcessor>
 {
+
+    /**
+     * Retrieves the priority of this processor. A lower value specifies a higher priority and the mapped properties / group name of
+     * processors with higher priorities may override those of lower priorities.
+     *
+     * @return the priority as an integer with {@code 50} as the default priority.
+     */
+    default int getPriority()
+    {
+        return 50;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default int compareTo(final GroupProcessor other)
+    {
+        int res = Integer.compare(this.getPriority(), other.getPriority());
+        if (res == 0)
+        {
+            res = this.getClass().getName().compareTo(other.getClass().getName());
+        }
+        return res;
+    }
 
     /**
      * Maps data from a Keycloak group representation to a description of an Alfresco node for the authority container.
      *
      * @param group
-     *            the Keycloak group representation
+     *     the Keycloak group representation
      * @param groupNodeDescription
-     *            the Alfresco node description
+     *     the Alfresco node description
      */
     void mapGroup(GroupRepresentation group, NodeDescription groupNodeDescription);
+
+    /**
+     * Maps a Keycloak group representation to the group name to use in Alfresco.
+     *
+     * @param group
+     *     the Keycloak group representation
+     * @return the Alfresco group name
+     */
+    default Optional<String> mapGroupName(final GroupRepresentation group)
+    {
+        return Optional.empty();
+    }
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/SimpleGroupAttributeProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/SimpleGroupAttributeProcessor.java
@@ -15,6 +15,9 @@
  */
 package de.acosix.alfresco.keycloak.repo.sync;
 
+import java.util.Optional;
+
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.sync.NodeDescription;
 import org.keycloak.representations.idm.GroupRepresentation;
 
@@ -23,19 +26,28 @@ import org.keycloak.representations.idm.GroupRepresentation;
  *
  * @author Axel Faust
  */
-public class SimpleGroupAttributeProcessor extends BaseAttributeProcessor
-        implements GroupProcessor
+public class SimpleGroupAttributeProcessor extends BaseAttributeProcessor implements GroupProcessor
 {
 
     protected boolean enabled;
 
     /**
      * @param enabled
-     *            the enabled to set
+     *     the enabled to set
      */
     public void setEnabled(final boolean enabled)
     {
         this.enabled = enabled;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority()
+    {
+        return this.priority;
     }
 
     /**
@@ -51,4 +63,13 @@ public class SimpleGroupAttributeProcessor extends BaseAttributeProcessor
         }
     }
 
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> mapGroupName(final GroupRepresentation group)
+    {
+        return this.enabled ? this.mapAuthorityName(ContentModel.PROP_AUTHORITY_NAME, group.getAttributes()) : Optional.empty();
+    }
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/SimpleUserAttributeProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/SimpleUserAttributeProcessor.java
@@ -18,7 +18,9 @@ package de.acosix.alfresco.keycloak.repo.sync;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.security.sync.NodeDescription;
 import org.alfresco.service.namespace.QName;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -28,19 +30,28 @@ import org.keycloak.representations.idm.UserRepresentation;
  *
  * @author Axel Faust
  */
-public class SimpleUserAttributeProcessor extends BaseAttributeProcessor
-        implements UserProcessor
+public class SimpleUserAttributeProcessor extends BaseAttributeProcessor implements UserProcessor
 {
 
     protected boolean enabled;
 
     /**
      * @param enabled
-     *            the enabled to set
+     *     the enabled to set
      */
     public void setEnabled(final boolean enabled)
     {
         this.enabled = enabled;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPriority()
+    {
+        return this.priority;
     }
 
     /**
@@ -64,6 +75,16 @@ public class SimpleUserAttributeProcessor extends BaseAttributeProcessor
     public Collection<QName> getMappedProperties()
     {
         return this.enabled ? new HashSet<>(this.attributePropertyQNameMappings.values()) : Collections.emptySet();
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<String> mapUserName(final UserRepresentation user)
+    {
+        return this.enabled ? this.mapAuthorityName(ContentModel.PROP_USERNAME, user.getAttributes()) : Optional.empty();
     }
 
 }

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/UserProcessor.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/sync/UserProcessor.java
@@ -16,6 +16,7 @@
 package de.acosix.alfresco.keycloak.repo.sync;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.alfresco.repo.security.sync.NodeDescription;
 import org.alfresco.service.namespace.QName;
@@ -28,16 +29,41 @@ import org.keycloak.representations.idm.UserRepresentation;
  *
  * @author Axel Faust
  */
-public interface UserProcessor
+public interface UserProcessor extends Comparable<UserProcessor>
 {
+
+    /**
+     * Retrieves the priority of this processor. A lower value specifies a higher priority and the mapped properties / user name of
+     * processors with higher priorities may override those of lower priorities.
+     *
+     * @return the priority as an integer with {@code 50} as the default priority.
+     */
+    default int getPriority()
+    {
+        return 50;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default int compareTo(final UserProcessor other)
+    {
+        int res = Integer.compare(this.getPriority(), other.getPriority());
+        if (res == 0)
+        {
+            res = this.getClass().getName().compareTo(other.getClass().getName());
+        }
+        return res;
+    }
 
     /**
      * Maps data from a Keycloak user representation to a description of an Alfresco node for the person.
      *
      * @param user
-     *            the Keycloak user representation
+     *     the Keycloak user representation
      * @param personNodeDescription
-     *            the Alfresco node description
+     *     the Alfresco node description
      */
     void mapUser(UserRepresentation user, NodeDescription personNodeDescription);
 
@@ -47,4 +73,16 @@ public interface UserProcessor
      * @return the set of person node properties mapped by this instance
      */
     Collection<QName> getMappedProperties();
+
+    /**
+     * Maps a Keycloak user representation to the user name to use in Alfresco.
+     *
+     * @param group
+     *     the Keycloak user representation
+     * @return the Alfresco user name
+     */
+    default Optional<String> mapUserName(final UserRepresentation group)
+    {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
This pull request improves the handling of user/group names during synchronisation and fixes an issue with exposing resource roles for permission management. User processors can now also provide overrides to the default mapping of the user name (like groups in one of the recent pull requests). Dedicated mapping operations for user/group names were added for use cases where only that detail is relevant (e.g. summary name collection operations), and a new priority mechanism ensures that processors may override the mapping state of others in a predictable order.