### PR TITLE
Fix error on failed Bearer authentication

### DIFF
--- a/docker-test/src/main/resources/share/Dockerfile
+++ b/docker-test/src/main/resources/share/Dockerfile
@@ -18,5 +18,5 @@ RUN java -jar ${alfresco.share.docker.mmt.path}/alfresco-mmt*.jar install \
 
 RUN sed -i 's/<secure>true<\/secure>/<secure>false<\/secure>/' ${alfresco.share.docker.tomcat.path}/conf/web.xml
 
-COPY share.xml ${alfresco.repo.docker.tomcat.path}/conf/Catalina/localhost/share.xml
-COPY share-config-custom.xml ${alfresco.repo.docker.tomcat.path}/shared/classes/alfresco/web-extension/share-config-custom.xml
+COPY share.xml ${alfresco.share.docker.tomcat.path}/conf/Catalina/localhost/share.xml
+COPY share-config-custom.xml ${alfresco.share.docker.tomcat.path}/shared/classes/alfresco/web-extension/share-config-custom.xml

--- a/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/ResponseHeaderCookieCaptureServletHttpFacade.java
+++ b/repository/src/main/java/de/acosix/alfresco/keycloak/repo/authentication/ResponseHeaderCookieCaptureServletHttpFacade.java
@@ -23,11 +23,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import org.alfresco.util.Pair;
-import org.keycloak.adapters.servlet.ServletHttpFacade;
+import org.keycloak.adapters.servlet.OIDCServletHttpFacade;
 import org.keycloak.adapters.spi.HttpFacade;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * This {@link HttpFacade} wraps servlet requests and responses in such a way that any response headers / cookies being set by Keycloak
@@ -36,7 +36,7 @@ import org.keycloak.adapters.spi.HttpFacade;
  *
  * @author Axel Faust
  */
-public class ResponseHeaderCookieCaptureServletHttpFacade extends ServletHttpFacade
+public class ResponseHeaderCookieCaptureServletHttpFacade extends OIDCServletHttpFacade
 {
 
     protected final Map<Pair<String, String>, jakarta.servlet.http.Cookie> cookies = new HashMap<>();


### PR DESCRIPTION
This PR fixes a ClassCastException within Keycloak code called by this module, relevant only when a Bearer authentication fails.

Fixes #53